### PR TITLE
remove slash that's causing error

### DIFF
--- a/src/com/duplocloud/Client.groovy
+++ b/src/com/duplocloud/Client.groovy
@@ -107,11 +107,11 @@ class Client {
   
 
   public listSecrets(String tenantId) {
-    return this.doGet("/v3/subscriptions/${tenantId}/k8s/secret")
+    return this.doGet("v3/subscriptions/${tenantId}/k8s/secret")
   }
 
   public listConfigmaps(String tenantId) {
-    return this.doGet("/v3/subscriptions/${tenantId}/k8s/configmap")
+    return this.doGet("v3/subscriptions/${tenantId}/k8s/configmap")
   }
 
   public createOrUpdateK8sConfigMap(String tenantId, String name, Map<String,String> data) {


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixed incorrect URL paths in `listSecrets` and `listConfigmaps` methods by removing leading slashes. This change corrects the request errors when interacting with the DuploCloud API.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Client.groovy</strong><dd><code>Fix Incorrect URL Paths in Secrets and Configmaps Methods</code></dd></summary>
<hr>
      
src/com/duplocloud/Client.groovy

<li>Removed leading slashes from the URL paths in <code>listSecrets</code> and <br><code>listConfigmaps</code> methods to fix request errors.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/pipeline-library-duplocloud/pull/11/files#diff-b9380d8fcf727fee22d09196988272a90209ef1ac6e5e8c07477e3ff40c535bb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

